### PR TITLE
Fix create initiative redirection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,24 +5,9 @@ source "https://rubygems.org"
 ruby RUBY_VERSION
 
 gem "decidim", git: "https://github.com/OpenSourcePolitics/decidim.git", branch: "alt/petition_merge"
-# gem "decidim-consultations", git: "https://github.com/OpenSourcePolitics/decidim.git", branch: "alt/petition_merge"
 gem "decidim-initiatives", git: "https://github.com/OpenSourcePolitics/decidim.git", branch: "alt/petition_merge"
 
-# gem "decidim", path: "../../decidim-petition"
-# gem "decidim-consultations", path: "../../decidim-petition"
-# gem "decidim-initiatives", path: "../../decidim-petition"
-
 gem "decidim-term_customizer", git: "https://github.com/OpenSourcePolitics/decidim-module-term_customizer.git", branch: "0.dev"
-
-# gem "omniauth-decidim", git: "https://github.com/OpenSourcePolitics/decidim.git"
-# gem "decidim-omniauth_extras", git: "https://github.com/OpenSourcePolitics/decidim.git"
-# gem "decidim-initiatives_extras", git: "https://github.com/OpenSourcePolitics/decidim.git"
-
-# gem "omniauth-decidim", path: "../omniauth-decidim"
-# gem "decidim-omniauth_extras", path: "../decidim-module-omniauth_extras"
-# gem "decidim-initiatives_extras", path: "../decidim-module-initiatives_extras"
-
-# gem "decidim-blazer", path: "../decidim-module-blazer"
 
 gem "bootsnap"
 gem "puma", ">= 4.3"
@@ -49,7 +34,6 @@ group :development, :test do
   gem "byebug", "~> 11.0", platform: :mri
 
   gem "decidim-dev", git: "https://github.com/OpenSourcePolitics/decidim.git", branch: "alt/petition_merge"
-  # gem "decidim-dev", path: "../../decidim-petition"
 end
 
 group :development do

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,13 +5,23 @@ module ApplicationHelper
     return true if request.env["PATH_INFO"].end_with?("/users/sign_in")
     return true if request.env["PATH_INFO"].end_with?("/committee_requests/new")
 
-    (available_authorizations? && request.env.dig(:available_authorizations).include?(provider_name.to_s))
+    (available_authorizations? && available_authorizations_for(provider_name.to_s))
   end
 
   private
 
   def available_authorizations?
-    request.env.dig(:available_authorizations).present?
+    request.env.dig(:available_authorizations).present? || current_organization.available_authorizations.present?
+  end
+
+  def available_authorizations
+    return current_organization.available_authorizations if request.env.dig(:available_authorizations).blank?
+
+    request.env.dig(:available_authorizations)
+  end
+
+  def available_authorizations_for(provider_name)
+    available_authorizations.include?(provider_name.to_s)
   end
 
   def omniauth_buttons_cache_version

--- a/app/views/decidim/authorization_modals/_content.html.erb
+++ b/app/views/decidim/authorization_modals/_content.html.erb
@@ -10,11 +10,11 @@
     </div>
   </div>
 <% else %>
-  <% base_code = authorizations.global_code || :missing %>
+  <% base_code = authorizations&.global_code || :missing %>
   <div class="<%= base_code %>-authorization">
     <h2 class="section-heading"><%= t ".#{base_code}.title" %></h2>
   </div>
-  <% authorizations.statuses.each do |status| %>
+  <% authorizations&.statuses&.each do |status| %>
     <% next if status.ok? || (authorizations.global_code && status.code != base_code) || authorization_anti_affinity.include?(status.handler_name) %>
     <p><%= t ".#{status.code}.explanation", authorization: t("#{status.handler_name}.name", scope: "decidim.authorization_handlers") %></p>
     <% if status.data[:extra_explanation] %>

--- a/app/views/decidim/initiatives/initiatives/_index_header.html.erb
+++ b/app/views/decidim/initiatives/initiatives/_index_header.html.erb
@@ -2,15 +2,8 @@
   <h1 id="initiatives-count" class="title-action__title section-heading">
     <%= render partial: "count" %>
   </h1>
-  <% if current_user && allowed_to?(:create, :initiative) %>
-    <%= link_to create_initiative_path(:select_initiative_type), class: "title-action__action button small" do %>
-        <%= t(".new_initiative") %>
-        <%= icon "plus", aria_label: t(".new_initiative"), role: "img" %>
-    <% end %>
-  <% else %>
-    <%= authorized_creation_modal_button_to create_initiative_path(:select_initiative_type), remote: true, class: "title-action__action button small hollow" do %>
-      <%= t(".new_initiative") %>
-      <%= icon "plus" %>
-    <% end %>
+  <%= link_to create_initiative_path(:select_initiative_type), class: "title-action__action button small" do %>
+    <%= t(".new_initiative") %>
+    <%= icon "plus", aria_label: t(".new_initiative"), role: "img" %>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -224,13 +224,13 @@ en:
         fill_data:
           back: Back
           continue: Continue
-          fill_data_help: Fill data help
+          fill_data_help: Review the content of your initiative. Is your title easy to understand? Is the objective of your initiative clear?
           initiative_type: Initiative type
           select_scope: Select scope
         finish:
           back: Back
           back_to_initiatives: Back to initiatives
-          callout_text: Callout text
+          callout_text: Congratulations! Your initiative has been successfully created."
           confirm: Confirm
           edit_my_initiative: Edit my initiative
           go_to_my_initiatives: Go to my initiatives
@@ -238,10 +238,10 @@ en:
         previous_form:
           back: Back
           continue: Continue
-          help: Help
+          help: What does the initiative consist of? Write down the title and description. We recommend a short and concise title and a description focused on the proposed solution.
         promotal_committee:
           back: Back
-          individual_help_text: Individual help text
+          individual_help_text: This kind of citizen initiative requires a Promoting Commission consisting of at least 2 people (attestors). You must share the following link with the other people that are part of this initiative. When your contacts receive this link they will have to follow the indicated steps.
       form:
         add_attachments: Ajouter un document
         attachment_legend: Document

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -4,3 +4,136 @@ require "decidim/core/test/factories"
 require "decidim/system/test/factories"
 require "decidim/initiatives/test/factories"
 require "decidim/comments/test/factories"
+
+FactoryBot.modify do
+  factory :initiative, class: "Decidim::Initiative" do
+    title { generate_localized_title }
+    description { generate_localized_title }
+    organization
+    author { create(:user, :confirmed, organization: organization) }
+    published_at { Time.current }
+    state { "published" }
+    signature_type { "online" }
+    signature_start_date { Date.current - 1.day }
+    signature_end_date { Date.current + 120.days }
+    online_votes { { "total": 0 } }
+    offline_votes { { "total": 0 } }
+    answer_date {}
+    area {}
+    decidim_initiatives_archive_categories_id {}
+
+    scoped_type do
+      create(:initiatives_type_scope,
+             type: create(:initiatives_type, organization: organization, signature_type: signature_type))
+    end
+
+    after(:create) do |initiative|
+      if initiative.author.is_a?(Decidim::User) && Decidim::Authorization.where(user: initiative.author).where.not(granted_at: nil).none?
+        create(:authorization, user: initiative.author, granted_at: Time.now.utc)
+      end
+      create_list(:initiatives_committee_member, 3, initiative: initiative)
+    end
+
+    trait :with_area do
+      area { create(:area, organization: organization) }
+    end
+
+    trait :archived do
+      decidim_initiatives_archive_categories_id { create(:archive_category, organization: organization).id }
+    end
+
+    trait :with_answer do
+      answer { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+      answer_url { ::Faker::Internet.url }
+      answered_at { Time.current }
+    end
+
+    trait :created do
+      state { "created" }
+      published_at { nil }
+      signature_start_date { nil }
+      signature_end_date { nil }
+    end
+
+    trait :validating do
+      state { "validating" }
+      published_at { nil }
+      signature_start_date { nil }
+      signature_end_date { nil }
+    end
+
+    trait :published do
+      state { "published" }
+    end
+
+    trait :unpublished do
+      published_at { nil }
+    end
+
+    trait :accepted do
+      state { "accepted" }
+    end
+
+    trait :discarded do
+      state { "discarded" }
+    end
+
+    trait :rejected do
+      state { "rejected" }
+    end
+
+    trait :examinated do
+      state { "examinated" }
+      answer_date { Date.current - 3.days }
+    end
+
+    trait :debatted do
+      state { "debatted" }
+      answer_date { Date.current - 3.days }
+    end
+
+    trait :classified do
+      state { "classified" }
+      answer_date { Date.current - 3.days }
+    end
+
+    trait :online do
+      signature_type { "online" }
+    end
+
+    trait :offline do
+      signature_type { "offline" }
+    end
+
+    trait :acceptable do
+      signature_start_date { Date.current - 3.months }
+      signature_end_date { Date.current - 2.months }
+      signature_type { "online" }
+
+      after(:build) do |initiative|
+        initiative.online_votes["total"] = initiative.supports_required + 1
+      end
+    end
+
+    trait :rejectable do
+      signature_start_date { Date.current - 3.months }
+      signature_end_date { Date.current - 2.months }
+      signature_type { "online" }
+
+      after(:build) do |initiative|
+        initiative.online_votes["total"] = 0
+      end
+    end
+
+    trait :with_user_extra_fields_collection do
+      scoped_type do
+        create(:initiatives_type_scope,
+               type: create(:initiatives_type, :with_user_extra_fields_collection, organization: organization))
+      end
+    end
+
+    trait :with_area do
+      area { create(:area, organization: organization) }
+    end
+  end
+end

--- a/spec/system/create_initiative_spec.rb
+++ b/spec/system/create_initiative_spec.rb
@@ -15,10 +15,7 @@ describe "Initiative", type: :system do
       expect(page).to have_current_path("/initiatives")
     end
   end
-  before do
-    create(:authorization, user: authorized_user)
-    login_as authorized_user, scope: :user
-  end
+
   context "when access to functionality" do
     before do
       switch_to_host(organization.host)
@@ -50,7 +47,354 @@ describe "Initiative", type: :system do
     let!(:other_initiative_type_scope) { create(:initiatives_type_scope, type: initiative_type) }
 
     before do
+      switch_to_host(organization.host)
       visit decidim_initiatives.create_initiative_path(id: :select_initiative_type)
+    end
+
+    context "without validations" do
+      before do
+        switch_to_host(organization.host)
+        create(:authorization, user: authorized_user)
+        login_as authorized_user, scope: :user
+        visit decidim_initiatives.create_initiative_path(id: :select_initiative_type)
+      end
+      context "and select initiative type" do
+        it "Offers contextual help" do
+          within ".callout.secondary" do
+            expect(page).to have_content("Citizen initiatives are a means by which the citizenship can intervene so that the City Council can undertake actions in defence of the general interest that are within fields of municipal jurisdiction. Which initiative do you want to launch?")
+          end
+        end
+
+        it "Shows the available initiative types" do
+          within "main" do
+            expect(page).to have_content(translated(initiative_type.title, locale: :en))
+            expect(page).to have_content(ActionView::Base.full_sanitizer.sanitize(translated(initiative_type.description, locale: :en), tags: []))
+          end
+        end
+
+        it "Do not show initiative types without related scopes" do
+          within "main" do
+            expect(page).not_to have_content(translated(other_initiative_type.title, locale: :en))
+            expect(page).not_to have_content(ActionView::Base.full_sanitizer.sanitize(translated(other_initiative_type.description, locale: :en), tags: []))
+          end
+        end
+      end
+
+      context "and fill basic data" do
+        before do
+          find_button("I want to promote this initiative").click
+        end
+
+        it "Has a hidden field with the selected initiative type" do
+          expect(page).to have_xpath("//input[@id='initiative_type_id']", visible: false)
+          expect(find(:xpath, "//input[@id='initiative_type_id']", visible: false).value).to eq(initiative_type.id.to_s)
+        end
+
+        it "Have fields for title and description" do
+          expect(page).to have_xpath("//input[@id='initiative_title']")
+          expect(page).to have_xpath("//textarea[@id='initiative_description']", visible: false)
+        end
+
+        it "Offers contextual help" do
+          within ".callout.secondary" do
+            expect(page).to have_content("What does the initiative consist of? Write down the title and description. We recommend a short and concise title and a description focused on the proposed solution.")
+          end
+        end
+      end
+
+      context "when there is only one initiative type" do
+        let!(:other_initiative_type) { nil }
+
+        it "doesn't displays initiative types" do
+          expect(page).not_to have_current_path(decidim_initiatives.create_initiative_path(id: :select_initiative_type))
+        end
+
+        it "doesn't display the 'choose' step" do
+          within ".wizard__steps" do
+            expect(page).not_to have_content("Choose")
+          end
+        end
+
+        it "Has a hidden field with the selected initiative type" do
+          expect(page).to have_xpath("//input[@id='initiative_type_id']", visible: false)
+          expect(find(:xpath, "//input[@id='initiative_type_id']", visible: false).value).to eq(initiative_type.id.to_s)
+        end
+
+        it "Have fields for title and description" do
+          expect(page).to have_xpath("//input[@id='initiative_title']")
+          expect(page).to have_xpath("//textarea[@id='initiative_description']", visible: false)
+        end
+
+        it "Offers contextual help" do
+          within ".callout.secondary" do
+            expect(page).to have_content("What does the initiative consist of? Write down the title and description. We recommend a short and concise title and a description focused on the proposed solution.")
+          end
+        end
+      end
+
+      context "when Show similar initiatives" do
+        let!(:initiative) { create(:initiative, organization: organization) }
+
+        before do
+          find_button("I want to promote this initiative").click
+          fill_in "Title", with: translated(initiative.title, locale: :en)
+          fill_in "initiative_description", with: translated(initiative.description, locale: :en)
+          find_button("Continue").click
+        end
+
+        it "Similar initiatives view is shown" do
+          expect(page).to have_content("Compare")
+        end
+
+        it "Offers contextual help" do
+          within ".callout.secondary" do
+            expect(page).to have_content("If any of the following initiatives is similar to yours we encourage you to sign it. Your proposal will have more possibilities to get done.")
+          end
+        end
+
+        it "Contains data about the similar initiative found" do
+          expect(page).to have_content(translated(initiative.title, locale: :en))
+          expect(page).to have_content(ActionView::Base.full_sanitizer.sanitize(translated(initiative.description, locale: :en), tags: []))
+          expect(page).to have_content(initiative.author_name)
+        end
+      end
+
+      context "when Create initiative" do
+        let(:initiative) { build(:initiative) }
+
+        context "when there is several initiatives type" do
+          before do
+            find_button("I want to promote this initiative").click
+            fill_in "Title", with: translated(initiative.title, locale: :en)
+            fill_in "initiative_description", with: translated(initiative.description, locale: :en)
+            find_button("Continue").click
+          end
+
+          it "Create view is shown" do
+            expect(page).to have_content("Create")
+          end
+
+          it "Offers contextual help" do
+            within ".callout.secondary" do
+              expect(page).to have_content("Review the content of your initiative. Is your title easy to understand? Is the objective of your initiative clear?")
+            end
+          end
+
+          it "Information collected in previous steps is already filled" do
+            expect(find(:xpath, "//input[@id='initiative_type_id']", visible: false).value).to eq(initiative_type.id.to_s)
+            expect(find(:xpath, "//input[@id='initiative_title']").value).to eq(translated(initiative.title, locale: :en))
+            expect(find(:xpath, "//textarea[@id='initiative_description']", visible: false).value).to eq(translated(initiative.description, locale: :en))
+          end
+
+          context "when only one signature collection and scope are available" do
+            let(:other_initiative_type_scope) { nil }
+            let(:initiative_type) { create(:initiatives_type, organization: organization, minimum_committee_members: initiative_type_minimum_committee_members, signature_type: "offline") }
+
+            it "hides and automatically selects the values" do
+              expect(page).not_to have_content("Scope")
+              expect(find(:xpath, "//input[@id='initiative_type_id']", visible: false).value).to eq(initiative_type.id.to_s)
+            end
+          end
+
+          context "when the initiative type does not enable custom signature end date" do
+            it "does not show the signature end date" do
+              expect(page).not_to have_content("End of signature collection period")
+            end
+          end
+
+          context "when the initiative type enables custom signature end date" do
+            let(:initiative_type) { create(:initiatives_type, :custom_signature_end_date_enabled, organization: organization, minimum_committee_members: initiative_type_minimum_committee_members, signature_type: "offline") }
+
+            it "shows the signature end date" do
+              expect(page).to have_content("End of signature collection period")
+            end
+          end
+
+          context "when the initiative type does not enable area" do
+            it "does not show the area" do
+              expect(page).not_to have_content("Area")
+            end
+          end
+
+          context "when the initiative type enables area" do
+            let(:initiative_type) { create(:initiatives_type, :area_enabled, organization: organization, minimum_committee_members: initiative_type_minimum_committee_members, signature_type: "offline") }
+
+            it "shows the area" do
+              # Update test according to commit : 4e180fdf2b7c1a9994dbbaf185646777f3735d21
+              expect(page).not_to have_content("Area")
+            end
+          end
+        end
+
+        context "when there is only one initiative type" do
+          let!(:other_initiative_type) { nil }
+
+          before do
+            fill_in "Title", with: translated(initiative.title, locale: :en)
+            fill_in "initiative_description", with: translated(initiative.description, locale: :en)
+            find_button("Continue").click
+          end
+
+          it "have no 'Initiative type' grey field" do
+            expect(page).not_to have_content("Initiative type")
+            expect(page).not_to have_css("#type_description")
+          end
+        end
+      end
+
+      context "when Promotal committee" do
+        let(:initiative) { build(:initiative, organization: organization, scoped_type: initiative_type_scope) }
+
+        before do
+          find_button("I want to promote this initiative").click
+
+          fill_in "Title", with: translated(initiative.title, locale: :en)
+          fill_in "initiative_description", with: translated(initiative.description, locale: :en)
+          find_button("Continue").click
+
+          select(translated(initiative_type_scope.scope.name, locale: :en), from: "Scope")
+          find_button("Continue").click
+        end
+
+        it "shows the promoter committee" do
+          expect(page).to have_content("Promoter committee")
+        end
+
+        it "Offers contextual help" do
+          within ".callout.secondary" do
+            expect(page).to have_content("This kind of citizen initiative requires a Promoting Commission consisting of at least #{initiative_type_minimum_committee_members} people (attestors). You must share the following link with the other people that are part of this initiative. When your contacts receive this link they will have to follow the indicated steps.")
+          end
+        end
+
+        it "Contains a link to invite other users" do
+          expect(page).to have_content("/committee_requests/new")
+        end
+
+        it "Contains a button to continue with next step" do
+          expect(page).to have_content("Continue")
+        end
+
+        context "when minimum committee size is zero" do
+          let(:initiative_type_minimum_committee_members) { 0 }
+
+          it "skips to next step" do
+            within(".step--active") do
+              expect(page).not_to have_content("Promoter committee")
+              expect(page).to have_content("Finish")
+            end
+          end
+        end
+
+        context "when minimum committee size is equal to 1" do
+          let(:initiative_type_minimum_committee_members) { 1 }
+
+          it "displays promoting committee wizard" do
+            within ".wizard__steps" do
+              expect(page).to have_content("Promoter committee")
+            end
+          end
+        end
+
+        context "and it's disabled at the type scope" do
+          let(:initiative_type) { create(:initiatives_type, organization: organization, promoting_committee_enabled: false, signature_type: signature_type) }
+
+          it "skips the promoting committee settings" do
+            expect(page).not_to have_content("Promoter committee")
+            expect(page).to have_content("Finish")
+          end
+        end
+      end
+
+      context "when Finish", processing_uploads_for: Decidim::AttachmentUploader do
+        let(:initiative) { build(:initiative) }
+
+        before do
+          find_button("I want to promote this initiative").click
+
+          fill_in "Title", with: translated(initiative.title, locale: :en)
+          fill_in "initiative_description", with: translated(initiative.description, locale: :en)
+          find_button("Continue").click
+
+          select(translated(initiative_type_scope.scope.name, locale: :en), from: "Scope")
+          attach_file :initiative_add_documents, Decidim::Dev.asset("Exampledocument.pdf")
+          find_button("Continue").click
+        end
+
+        context "when minimum committee size is above one" do
+          before do
+            find_link("Continue").click
+          end
+
+          it "finish view is shown" do
+            expect(page).to have_content("Finish")
+          end
+
+          it "Offers contextual help" do
+            within ".callout.alert" do
+              expect(page).to have_content("Congratulations! Your initiative has been successfully created.")
+            end
+          end
+
+          it "displays an edit link" do
+            within ".actions" do
+              expect(page).to have_link("Edit my initiative")
+            end
+          end
+
+          it "doesn't displays a send to technical validation link" do
+            expected_message = "You are going to send the initiative for an admin to review it and publish it. Once published you will not be able to edit it. Are you sure?"
+            within ".actions" do
+              expect(page).not_to have_link("Send my initiative")
+              expect(page).not_to have_selector "a[data-confirm='#{expected_message}']"
+            end
+          end
+        end
+
+        context "when minimum committee size is zero" do
+          let(:initiative) { build(:initiative, organization: organization, scoped_type: initiative_type_scope) }
+          let(:initiative_type_minimum_committee_members) { 0 }
+
+          it "displays a send to technical validation link" do
+            within ".actions" do
+              expect(page).to have_link("Send my initiative")
+            end
+          end
+
+          it_behaves_like "initiatives path redirection"
+        end
+
+        context "when minimum committee size is equals to 1" do
+          let(:initiative) { build(:initiative, organization: organization, scoped_type: initiative_type_scope) }
+          let(:initiative_type_minimum_committee_members) { 1 }
+
+          before do
+            find_link("Continue").click
+          end
+
+          it "displays a send to technical validation link" do
+            within ".actions" do
+              expect(page).to have_link("Send my initiative")
+            end
+          end
+
+          it_behaves_like "initiatives path redirection"
+        end
+
+        context "when promoting committee is not enabled" do
+          let(:initiative) { build(:initiative, organization: organization, scoped_type: initiative_type_scope) }
+          let(:initiative_type_promoting_committee_enabled) { false }
+          let(:initiative_type_minimum_committee_members) { 0 }
+
+          it "displays a send to technical validation link" do
+            within ".actions" do
+              expect(page).to have_link("Send my initiative")
+            end
+          end
+
+          it_behaves_like "initiatives path redirection"
+        end
+      end
+
     end
 
     context "when user is not defined and creates new initiative" do

--- a/spec/system/create_initiative_spec.rb
+++ b/spec/system/create_initiative_spec.rb
@@ -51,6 +51,7 @@ describe "Initiative", type: :system do
       visit decidim_initiatives.create_initiative_path(id: :select_initiative_type)
     end
 
+    # rubocop:disable Capybara/VisibilityMatcher
     context "without validations" do
       before do
         switch_to_host(organization.host)
@@ -58,6 +59,7 @@ describe "Initiative", type: :system do
         login_as authorized_user, scope: :user
         visit decidim_initiatives.create_initiative_path(id: :select_initiative_type)
       end
+
       context "and select initiative type" do
         it "Offers contextual help" do
           within ".callout.secondary" do
@@ -185,6 +187,7 @@ describe "Initiative", type: :system do
             expect(find(:xpath, "//input[@id='initiative_title']").value).to eq(translated(initiative.title, locale: :en))
             expect(find(:xpath, "//textarea[@id='initiative_description']", visible: false).value).to eq(translated(initiative.description, locale: :en))
           end
+          # rubocop:enable Capybara/VisibilityMatcher
 
           context "when only one signature collection and scope are available" do
             let(:other_initiative_type_scope) { nil }
@@ -394,7 +397,6 @@ describe "Initiative", type: :system do
           it_behaves_like "initiatives path redirection"
         end
       end
-
     end
 
     context "when user is not defined and creates new initiative" do

--- a/spec/system/create_initiative_spec.rb
+++ b/spec/system/create_initiative_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Initiative", type: :system do
+  let(:organization) { create(:organization) }
+  let(:authorized_user) { create(:user, :confirmed, organization: organization) }
+
+  shared_examples "initiatives path redirection" do
+    it "redirects to initiatives path" do
+      accept_confirm do
+        click_link("Send my initiative")
+      end
+
+      expect(page).to have_current_path("/initiatives")
+    end
+  end
+  before do
+    create(:authorization, user: authorized_user)
+    login_as authorized_user, scope: :user
+  end
+  context "when access to functionality" do
+    before do
+      switch_to_host(organization.host)
+
+      create(:authorization, user: authorized_user)
+      login_as authorized_user, scope: :user
+
+      visit decidim_initiatives.initiatives_path
+    end
+
+    it "Initiatives page contains a create initiative button" do
+      expect(page).to have_content("New initiative")
+    end
+  end
+
+  context "when creates an initiative" do
+    let(:initiative_type_minimum_committee_members) { 2 }
+    let(:signature_type) { "any" }
+    let(:initiative_type_promoting_committee_enabled) { true }
+    let(:initiative_type) do
+      create(:initiatives_type,
+             organization: organization,
+             minimum_committee_members: initiative_type_minimum_committee_members,
+             promoting_committee_enabled: initiative_type_promoting_committee_enabled,
+             signature_type: signature_type)
+    end
+    let!(:other_initiative_type) { create(:initiatives_type, organization: organization) }
+    let!(:initiative_type_scope) { create(:initiatives_type_scope, type: initiative_type) }
+    let!(:other_initiative_type_scope) { create(:initiatives_type_scope, type: initiative_type) }
+
+    before do
+      visit decidim_initiatives.create_initiative_path(id: :select_initiative_type)
+    end
+
+    context "when user is not defined and creates new initiative" do
+      before do
+        switch_to_host(organization.host)
+
+        visit decidim_initiatives.initiatives_path
+        click_link "New initiative"
+      end
+
+      it "redirects to select initiative type" do
+        expect(page).to have_content("I want to promote this initiative")
+      end
+
+      context "when user click on promote initiative button" do
+        it "opens the omniauth modal" do
+          expect(page).to have_content("I want to promote this initiative")
+          click_button "I want to promote this initiative"
+          within "#loginModal" do
+            expect(page).to have_content("PLEASE SIGN IN")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Description 

- Add Nil safety for omniauth modal
- Allow non logged user to click 'Create initiative' button and being redirected to select_initiative_type path
- Add system specs
- Add nil safety in permissions helper
- Update initiative factory description because Senate doesn't use description editor in form

- User under 18 YO is only able to log as 'Signataire'