### PR TITLE
Discard initiative if created or validating

### DIFF
--- a/lib/extends/destroy_account_extend.rb
+++ b/lib/extends/destroy_account_extend.rb
@@ -34,9 +34,9 @@ module DestroyAccountExtend
       Decidim::Initiative.where(author: @user).find_each do |initiative|
         if initiative.supports_goal_reached?
           initiative.update!(state: "accepted")
+        elsif initiative.created? || initiative.validating?
+          initiative.update!(state: "discarded")
         else
-          next if initiative.state == "created" || initiative.state == "validating"
-
           initiative.update!(state: "rejected")
         end
       end

--- a/spec/commands/decidim/destroy_account_spec.rb
+++ b/spec/commands/decidim/destroy_account_spec.rb
@@ -99,20 +99,20 @@ module Decidim
 
         context "when initiative has not reached the signature threshold" do
           context "when initiative has created state" do
-            let!(:initiative) { create(:initiative, state: "created", scoped_type: scoped_type, organization: scoped_type.type.organization) }
+            let!(:initiative) { create(:initiative, :created, scoped_type: scoped_type, organization: scoped_type.type.organization) }
 
-            it "stays in the same state" do
+            it "is discarded" do
               command.call
-              expect(initiative.reload.state).to eq("created")
+              expect(initiative.reload.state).to eq("discarded")
             end
           end
 
           context "when initiative has technical validation" do
-            let!(:initiative) { create(:initiative, state: "validating", scoped_type: scoped_type, organization: scoped_type.type.organization) }
+            let!(:initiative) { create(:initiative, :validating, scoped_type: scoped_type, organization: scoped_type.type.organization) }
 
-            it "stays in the same state" do
+            it "is discarded" do
               command.call
-              expect(initiative.reload.state).to eq("validating")
+              expect(initiative.reload.state).to eq("discarded")
             end
           end
 


### PR DESCRIPTION
This PR aims to switch created & technical validation initiatives to discarded when the author deletes its account. 