### PR TITLE
Updates replicas after Zevent event (:

### DIFF
--- a/k8s/decidim/app-hpa.yml
+++ b/k8s/decidim/app-hpa.yml
@@ -7,8 +7,8 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: decidim-sen-deployment
-  minReplicas: 4
-  maxReplicas: 24
+  minReplicas: 10
+  maxReplicas: 40
   metrics:
   - type: Resource
     resource:


### PR DESCRIPTION
Zevent a pointé vers le site de pétitions du sénat, et en quelques minutes le site est tombé.

https://twitter.com/_G4ry/status/1568565290346094592

Il est aussi revenu en quelques minutes.

![Screenshot 2022-09-12 at 11-33-09 Compare Response time - Dashboards - Grafana](https://user-images.githubusercontent.com/1863453/189626213-bf3eebc9-28ed-42d4-9f92-d9dbb08ac07e.png)

Sur ce premier graph, on voit que le traffic commence à augmenter vers 13:35h (heure de Paris) pour atteindre un pic à 28k requêtes à 13:36. Les erreurs 499 augmentent tout aussi rapidement (je pense que c'est les personnes qui rafraîchissent leur navigateur.) Et les première 500 arrivent aussi vers 13:38.
(Attention à l'échelle log)

Par défaut, il y a 3 nœuds (machines virtuelles) qui tournent avec 4 pods.

![Screenshot 2022-09-12 at 11-33-43 Kubernetes _ Compute Resources _ Namespace (Pods) - Dashboards - Grafana](https://user-images.githubusercontent.com/1863453/189626195-9a8393de-a143-44ef-9dc1-b4b1d520a4f2.png)

Sur le graph ci dessus, nous voyons qu'à 13:36, des pods démarrent. 
(Une dizaine.)

![Screenshot 2022-09-12 at 11-33-26 Node Exporter _ USE Method _ Cluster - Dashboards - Grafana](https://user-images.githubusercontent.com/1863453/189626206-7833e870-d2b4-45c2-9343-4586997a0daf.png)

Il faut attendre que les nœuds démarrent aussi vers 13:39 pour que les pods suivants puissent aussi démarrer.

Pour améliorer le service, je propose:
 - de mettre les min pods à 10
 - de mettre les max pods à 40

Les 10 pods, sans activité, tiennent sur les 3 nœuds. Cela n'aura pas plus d'impact environnemental, et cela permettra d'absorber les pics plus rapidement.
Si il y a du traffic soudain, cela démarrera directement des nœuds physiques.
Et avec 40 pods, nous devrions pouvoir atteindre la limite de 10 nœuds physique.

Il est bien sur possible d'ajouter plus de nœuds physiques au repos, et d'avoir une limite encore plus haute pour absorber les demandes maximales.

 à nous de voir les metrics qui nous semblent raisonnables.

Enfin, sur ce dernier graph, on voit les nœuds physiques s'éteindre vers 14:40 quand la première vague est digérée.

![Screenshot 2022-09-12 at 17-17-37 Node Exporter _ USE Method _ Cluster - Dashboards - Grafana](https://user-images.githubusercontent.com/1863453/189692126-aa5114e9-e87b-4a79-9eea-1cb29f302aef.png)
