### PR TITLE
Add cleaner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby RUBY_VERSION
 gem "decidim", git: "https://github.com/OpenSourcePolitics/decidim.git", branch: "alt/petition_merge"
 gem "decidim-initiatives", git: "https://github.com/OpenSourcePolitics/decidim.git", branch: "alt/petition_merge"
 
+gem "decidim-cleaner", git: "https://github.com/OpenSourcePolitics/decidim-module-cleaner.git", branch: "release/0.22-stable"
 gem "decidim-term_customizer", git: "https://github.com/OpenSourcePolitics/decidim-module-term_customizer.git", branch: "0.dev"
 
 gem "bootsnap"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/OpenSourcePolitics/decidim-module-cleaner.git
+  revision: 40fd22bf07783ec881a9931aa340d569c6ec8c02
+  branch: release/0.22-stable
+  specs:
+    decidim-cleaner (0.22.0.dev)
+      decidim-core (= 0.22.0.dev)
+
+GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-term_customizer.git
   revision: b083f1f2e398aa51606ea9adc928394b99b44be1
   branch: 0.dev
@@ -930,6 +938,7 @@ DEPENDENCIES
   dalli
   dalli-elasticache
   decidim!
+  decidim-cleaner!
   decidim-dev!
   decidim-initiatives!
   decidim-term_customizer!

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -26,3 +26,11 @@
   CleanSessions:
     cron: '0 1 * * *'
     class: CleanSessions
+  CleanAdminLogs:
+    cron: "0 9 0 * * *"
+    class: Decidim::Cleaner::CleanAdminLogsJob
+    queue: scheduled
+  CleanInactiveUsers:
+    cron: "0 9 0 * * *"
+    class: Decidim::Cleaner::CleanInactiveUsersJob
+    queue: scheduled

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -26,6 +26,9 @@
   CleanSessions:
     cron: '0 1 * * *'
     class: CleanSessions
+  AnonymizeInitiatives:
+    cron: '0 1 * * *' # Run everyday at 1 am
+    class: AnonymizeInitiativesJob
   CleanAdminLogs:
     cron: "0 9 0 * * *"
     class: Decidim::Cleaner::CleanAdminLogsJob

--- a/db/migrate/20230111155921_add_delete_admin_logs_to_organization.decidim_cleaner.rb
+++ b/db/migrate/20230111155921_add_delete_admin_logs_to_organization.decidim_cleaner.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# This migration comes from decidim_cleaner (originally 20230106105014)
+
+class AddDeleteAdminLogsToOrganization < ActiveRecord::Migration[5.0]
+  def change
+    add_column :decidim_organizations, :delete_admin_logs, :boolean, default: false, null: false
+    add_column :decidim_organizations, :delete_admin_logs_after, :integer
+  end
+end

--- a/db/migrate/20230111155922_add_delete_inactive_users_to_organization.decidim_cleaner.rb
+++ b/db/migrate/20230111155922_add_delete_inactive_users_to_organization.decidim_cleaner.rb
@@ -1,0 +1,8 @@
+# This migration comes from decidim_cleaner (originally 20230110150032)
+class AddDeleteInactiveUsersToOrganization < ActiveRecord::Migration[5.0]
+  def change
+    add_column :decidim_organizations, :delete_inactive_users, :boolean, default: false, null: false
+    add_column :decidim_organizations, :delete_inactive_users_email_after, :integer
+    add_column :decidim_organizations, :delete_inactive_users_after, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_15_081756) do
+ActiveRecord::Schema.define(version: 2023_01_11_155922) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -991,6 +991,11 @@ ActiveRecord::Schema.define(version: 2021_07_15_081756) do
     t.jsonb "admin_terms_of_use_body"
     t.string "time_zone", limit: 255, default: "UTC"
     t.string "deepl_api_key"
+    t.boolean "delete_admin_logs", default: false, null: false
+    t.integer "delete_admin_logs_after"
+    t.boolean "delete_inactive_users", default: false, null: false
+    t.integer "delete_inactive_users_email_after"
+    t.integer "delete_inactive_users_after"
     t.index ["host"], name: "index_decidim_organizations_on_host", unique: true
     t.index ["name"], name: "index_decidim_organizations_on_name", unique: true
   end


### PR DESCRIPTION
This PR adds the [module cleaner](https://github.com/OpenSourcePolitics/decidim-module-cleaner) to the repo.
It enables admins to automatically delete old admin logs and inactive users.